### PR TITLE
fix: quote argument-hint YAML values so Copilot CLI ≥1.0.65 loads all skills (closes #61)

### DIFF
--- a/commands/contacts.md
+++ b/commands/contacts.md
@@ -1,7 +1,7 @@
 ---
 description: List contacts by recent messaging activity
 allowed-tools: Bash(messages:*)
-argument-hint: [--limit N]
+argument-hint: "[--limit N]"
 ---
 
 # Contacts

--- a/commands/conversations.md
+++ b/commands/conversations.md
@@ -1,7 +1,7 @@
 ---
 description: List conversations with message counts
 allowed-tools: Bash(messages:*)
-argument-hint: [--limit N]
+argument-hint: "[--limit N]"
 ---
 
 # Conversations

--- a/commands/recent.md
+++ b/commands/recent.md
@@ -1,7 +1,7 @@
 ---
 description: Show most recent messages (who texted me?)
 allowed-tools: Bash(messages:*)
-argument-hint: [--limit N]
+argument-hint: "[--limit N]"
 ---
 
 # Recent Messages


### PR DESCRIPTION
Closes #61.

## Summary

Purely mechanical single-character transform to 3 file(s): wrap the value after `argument-hint:` in double quotes so YAML parses it as a **string** instead of a flow-sequence array. Fixes GitHub Copilot CLI ≥ 1.0.65 silently dropping the skill.

```diff
- argument-hint: [foo]
+ argument-hint: "[foo]"
```

Bare `[...]` is YAML flow-sequence syntax → the loader receives `["foo"]` (a list), fails its `str` validation, and rejects the SKILL without an error. Claude Code, VS Code Agent Skills, and every other loader document `argument-hint` as a string; the quoted-string form is what all reference docs show.

## Files (3)

- `commands/recent.md`
- `commands/conversations.md`
- `commands/contacts.md`

## Verification

- YAML round-trip via `yaml.safe_load` on every changed frontmatter reports `argument-hint` as `str`
- No vulnerable value contained `"` or `\`, so bare double-quote wrapping is safe

## Sources

- [Claude Code slash-commands / frontmatter reference](https://code.claude.com/docs/en/slash-commands) — `argument-hint` documented as a string
- [VS Code Agent Skills docs](https://code.visualstudio.com/docs/agent-customization/agent-skills) — same
